### PR TITLE
Update ReadMe.txt

### DIFF
--- a/Arcade_MiST/Pacman Hardware/ReadMe.txt
+++ b/Arcade_MiST/Pacman Hardware/ReadMe.txt
@@ -1,10 +1,5 @@
 Games that should work on this hardware
 
-Nibbler
-Fantasy
-Pioneer Balloon
-Vanguard
-Zarzon
 Piranha
 Titan
 The Glob/Beastie


### PR DESCRIPTION
Sorry but Nibbler, Fantasy, Pioneer Balloon, Vanguard, and Zarzon don't run on Pac-man hardware, they are a completely different platform (SNK). 

This list actually looks like it was lifted straight from a forum post about the BitKit product, the games are in the exact order I list them.

Titan does run on Pac hardware, it is essentially a rom hack of Piranha. I dumped it for MAME a couple years ago. 